### PR TITLE
update for Jest 16

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,11 +12,13 @@ npm install --save-dev jest-css-modules
 
 Update your package.json file's `jest` configuration:
 
+
 ```json
 {
   "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/jest-css-modules",
-  }
+    "transform": {
+       ".css": "<rootDir>/node_modules/jest-css-modules"
+    }
 }
 ```
 


### PR DESCRIPTION
update `scriptPreprocessor` is no longer in the [Jest api](https://facebook.github.io/jest/docs/configuration.html#configuration-options-configuration). It is now replaced with the `transform` API.