### PR TITLE
Update installation guide with support for Jest 18

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,8 @@ Update your package.json file's `jest` configuration:
 ```json
 {
   "jest": {
-    "transform": {
-       ".css": "<rootDir>/node_modules/jest-css-modules"
+    "moduleNameMapper": {
+      "\\.(css)$": "<rootDir>/node_modules/jest-css-modules"
     }
 }
 ```


### PR DESCRIPTION
As of Jest 18, the property is `moduleNameMapper`. For reference, see the WebPack tutorial: https://facebook.github.io/jest/docs/tutorial-webpack.html.

```js
"moduleNameMapper": {
  "\\.(css)$": "<rootDir>/node_modules/jest-css-modules"
}
```

Also, I noticed the README on npm is out of date with the latest README on GitHub.